### PR TITLE
Update autopilot.js

### DIFF
--- a/autopilot.js
+++ b/autopilot.js
@@ -418,7 +418,10 @@ async function maybeDoCasino(ns, player) {
 		await ns.sleep(200); // Wait a short while for the dust to settle.
 	} else if (casinoRanFileSet)
 		return ranCasino = true;
-	if (player.playtimeSinceLastAug < 60000) // If it's been less than 1 minute, wait a while to establish income
+	//If it's been less than 1 minute, wait a while to establish income
+	//Unless we have CashRoot Starter Kit, at which point we should head straight to the casino
+	//Or if BN8, as that also gives us plenty of starter cash to casino immediately
+	if (player.playtimeSinceLastAug < 60000 && !installedAugmentations.includes(`CashRoot Starter Kit`) && !player.bitNodeN == 8)
 		return;
 	if (player.money / player.playtimeSinceLastAug > 5e9 / 60000) // If we're making more than ~5b / minute, no need to run casino.
 		return ranCasino = true;


### PR DESCRIPTION
If we have CashRoot Starter Kit we can abuse the Casino as soon as we ascend, no reason to wait a minute and risk other scripts spending us down to below travel cost.

Additionally, if we are in BN 8, we have $250 million in starter funds, no need to delay.